### PR TITLE
Faster bioformats and Diff0

### DIFF
--- a/anilyze-data.py
+++ b/anilyze-data.py
@@ -138,7 +138,7 @@ def make_difference(directories, x, differenceNumber):
         dup.setTitle(windowName + "_dup")
 
         differenceNumberString = str(differenceNumber) #turns the integer input into a string (str)
-        imp = WindowManager.getImage(i)
+
         for n in range(1, differenceNumber+1):
             if n >= 1:
                 IJ.run(imp, "Delete Slice", "")


### PR DESCRIPTION
Fixed a bug in bioformats importer that caused Windows to run slowly when opening files. XML file as seed was very slow, however using a TIFF is much faster. Also added in conditional logic to account for user entering "0" for difference movie field. Skips this function. Tested and confirmed.